### PR TITLE
Level flow: remove timer; auto-advance on last enemy

### DIFF
--- a/src/config/balance.ts
+++ b/src/config/balance.ts
@@ -21,7 +21,13 @@ export const balance = {
   playerSpeed: 220,
   boostPerBullet: 0.2,
   blastRadius: 180,
+  blastArc: 120, // Angle in degrees
   blastKnockback: 220,
+  boostTelegraphThreshold: 0.8,
+
+  // Ally
+  allyEnabled: true,
+  allyStartLevel: 2,
 
   // Level
   levelTimeSec: 40,

--- a/src/scenes/UI.ts
+++ b/src/scenes/UI.ts
@@ -4,7 +4,7 @@ import { Game } from './Game';
 export class UI extends Phaser.Scene {
   private gameScene!: Game;
   private levelText!: Phaser.GameObjects.Text;
-  private timerText!: Phaser.GameObjects.Text;
+  private enemiesText!: Phaser.GameObjects.Text;
   private boostBarBg!: Phaser.GameObjects.Graphics;
   private boostBarFill!: Phaser.GameObjects.Graphics;
   private boostText!: Phaser.GameObjects.Text;
@@ -32,9 +32,9 @@ export class UI extends Phaser.Scene {
       )
       .setOrigin(1, 0);
 
-    // Timer Text
-    this.timerText = this.add
-      .text(this.scale.width - 10, 40, 'Time: 0', {
+    // Enemies Text
+    this.enemiesText = this.add
+      .text(this.scale.width - 10, 40, 'Enemies: 0', {
         fontSize: '24px',
         color: '#ffffff',
       })
@@ -81,12 +81,9 @@ export class UI extends Phaser.Scene {
 
       this.boostText.setText(`${Math.round(boostValue * 100)}%`);
     });
-  }
 
-  update() {
-    if (this.gameScene && this.gameScene['levelTimer']) {
-      const remaining = this.gameScene['levelTimer'].getRemainingSeconds();
-      this.timerText.setText(`Time: ${Math.ceil(remaining)}`);
-    }
+    this.gameScene.events.on('enemiesChanged', (count: number) => {
+      this.enemiesText.setText(`Enemies: ${count}`);
+    });
   }
 }

--- a/src/systems/Spawner.ts
+++ b/src/systems/Spawner.ts
@@ -18,15 +18,19 @@ export class Spawner {
     this.enemies = enemies;
   }
 
-  spawnEnemies() {
+  spawnEnemies(): Enemy[] {
     const numEnemies = this.level.enemiesForLevel(this.level.currentLevel);
     const ymax = this.scene.scale.height * balance.enemyTopZoneRatio;
+    const spawnedEnemies: Enemy[] = [];
 
     for (let i = 0; i < numEnemies; i++) {
       const x = Phaser.Math.Between(50, this.scene.scale.width - 50);
       const y = Phaser.Math.Between(50, ymax - 50);
       const enemy = new Enemy(this.scene, x, y);
       this.enemies.add(enemy);
+      spawnedEnemies.push(enemy);
     }
+
+    return spawnedEnemies;
   }
 }


### PR DESCRIPTION
- Remove level timer; level advances immediately after the last enemy is defeated.
- Track live enemy count; on zero → start next level after a short delay and clear bullets.
- UI: show “Enemies: N” (timer hidden).
- No changes to ally/game-over logic (lose only if all allies are dead once allies exist).
- format/lint/test/build pass.
